### PR TITLE
fix: apply cache invalidation for post when like and unlike is invoked

### DIFF
--- a/src/modules/like/like.controller.ts
+++ b/src/modules/like/like.controller.ts
@@ -21,10 +21,10 @@ export const likePost = async (req: Request, res: Response, next: NextFunction) 
 
 export const likeComment = async (req: Request, res: Response, next: NextFunction) => {
 	const { userId } = req as AuthenticatedRequest;
-	const { commentId } = req.body;
+	const { commentId, postId } = req.body;
 
 	try {
-		const result = await likeService.likeComment({ userId, commentId });
+		const result = await likeService.likeComment({ userId, commentId, postId });
 
 		res.status(STATUS_CODE.CREATED).json(result);
 	} catch (error) {
@@ -47,10 +47,10 @@ export const unlikePost = async (req: Request, res: Response, next: NextFunction
 
 export const unlikeComment = async (req: Request, res: Response, next: NextFunction) => {
 	const { userId } = req as AuthenticatedRequest;
-	const { commentId } = req.body;
+	const { commentId, postId } = req.body;
 
 	try {
-		const result = await likeService.unlikeComment({ commentId, userId });
+		const result = await likeService.unlikeComment({ commentId, userId, postId });
 
 		res.status(STATUS_CODE.SUCCESS).json(result);
 	} catch (error) {

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -27,11 +27,12 @@ export const likePost = async ({ userId, postId }: ILikePost) => {
 	}
 
 	await invalidatePaginationCache(`likes:posts:${postId}`, 3);
+	await invalidatePaginationCache('posts', 3);
 
 	return { like: true };
 };
 
-export const likeComment = async ({ userId, commentId }: ILikeComment) => {
+export const likeComment = async ({ userId, commentId, postId }: ILikeComment) => {
 	const existingLike = await prisma.like.findFirst({
 		where: { userId, commentId }
 	});
@@ -49,6 +50,7 @@ export const likeComment = async ({ userId, commentId }: ILikeComment) => {
 	}
 
 	await invalidatePaginationCache(`likes:comments:${commentId}`, 3);
+	await invalidatePaginationCache(`comments:posts:${postId}`, 3);
 
 	return { like: true };
 };
@@ -71,11 +73,12 @@ export const unlikePost = async ({ postId, userId }: IUnlikePost) => {
 	}
 
 	await invalidatePaginationCache(`likes:posts:${postId}`, 3);
+	await invalidatePaginationCache('posts', 3);
 
 	return { unlike: true };
 };
 
-export const unlikeComment = async ({ commentId, userId }: IUnlikeComment) => {
+export const unlikeComment = async ({ commentId, userId, postId }: IUnlikeComment) => {
 	const existingLike = await prisma.like.findFirst({
 		where: { userId, commentId }
 	});
@@ -93,6 +96,7 @@ export const unlikeComment = async ({ commentId, userId }: IUnlikeComment) => {
 	}
 
 	await invalidatePaginationCache(`likes:comments:${commentId}`, 3);
+	await invalidatePaginationCache(`comments:posts:${postId}`, 3);
 
 	return { unlike: true };
 };

--- a/src/modules/like/like.types.ts
+++ b/src/modules/like/like.types.ts
@@ -6,6 +6,7 @@ export type ILikePost = {
 export type ILikeComment = {
 	userId: string;
 	commentId: string;
+	postId: string;
 };
 
 export type IUnlikePost = {
@@ -16,6 +17,7 @@ export type IUnlikePost = {
 export type IUnlikeComment = {
 	commentId: string;
 	userId: string;
+	postId: string;
 };
 
 export type IGetPostLikes = {

--- a/src/modules/like/like.validation.ts
+++ b/src/modules/like/like.validation.ts
@@ -11,7 +11,8 @@ export const likePostSchema = z
 
 export const likeCommentSchema = z
 	.object({
-		commentId: z.uuid('Invalid comment id')
+		commentId: z.uuid('Invalid comment id'),
+		postId: z.uuid('Invalid post id')
 	})
 	.openapi({ description: 'Like a comment' });
 
@@ -23,7 +24,8 @@ export const unlikePostSchema = z
 
 export const unlikeCommentSchema = z
 	.object({
-		commentId: z.uuid('Invalid comment id')
+		commentId: z.uuid('Invalid comment id'),
+		postId: z.uuid('Invalid post id')
 	})
 	.openapi({ description: 'Unlike a comment' });
 


### PR DESCRIPTION
Apply cache invalidation for post list whenever like/unlike endpoint is called